### PR TITLE
Added composer 1.2.5 and Tipoff\Support. Nothing else was available to update per Github PR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "spatie/laravel-permission": "^4.0",
-        "tipoff/support": "^1.2.0"
+        "tipoff/support": "1.2.5"
     },
     "require-dev": {
         "tipoff/test-support": "^1.0"

--- a/src/AuthorizationServiceProvider.php
+++ b/src/AuthorizationServiceProvider.php
@@ -6,8 +6,6 @@ namespace Tipoff\Authorization;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Tipoff\Support\TipoffPackage;
-use Tipoff\Support\TipoffServiceProvider;
 
 class AuthorizationServiceProvider extends PackageServiceProvider
 {

--- a/src/AuthorizationServiceProvider.php
+++ b/src/AuthorizationServiceProvider.php
@@ -6,6 +6,8 @@ namespace Tipoff\Authorization;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Tipoff\Support\TipoffPackage;
+use Tipoff\Support\TipoffServiceProvider;
 
 class AuthorizationServiceProvider extends PackageServiceProvider
 {


### PR DESCRIPTION
I updated the composer for tipoff/support to 1.2.5 and then added in the Use Tipoff\Support into the AuthorizationServiceProvider.php. The other tasks in the PR https://github.com/tipoff/discounts/pull/21 were not available for me to update.