### PR TITLE
Fix migration for sqlite again.  Add tests to verify migration

### DIFF
--- a/database/migrations/2014_10_12_000001_modify_users_table.php
+++ b/database/migrations/2014_10_12_000001_modify_users_table.php
@@ -10,15 +10,9 @@ class ModifyUsersTable extends Migration
 {
     public function up()
     {
+        // Isolate rename in its own changeset, Sqlite has (silent) failures otherwise
         Schema::table('users', function (Blueprint $table) {
             $table->renameColumn('name', 'first_name');
-            $table->text('bio')->nullable()->after('password'); // Will be written in Markdown. The user profile image will come from Gravatar account for the email address.
-            $table->text('title')->nullable()->after('bio');
-            $table->softDeletes()->after('title');
-
-            // needed for Laravel Socialite
-            $table->string('provider_name')->nullable()->after('password');
-            $table->string('provider_id')->unique()->nullable()->after('provider');
         });
 
         Schema::table('users', function (Blueprint $table) {
@@ -28,6 +22,13 @@ class ModifyUsersTable extends Migration
             if (config("database.default") === "testing") {
                 $column->default('');
             }
+            $table->text('bio')->nullable()->after('password'); // Will be written in Markdown. The user profile image will come from Gravatar account for the email address.
+            $table->text('title')->nullable()->after('bio');
+            $table->softDeletes()->after('title');
+
+            // needed for Laravel Socialite
+            $table->string('provider_name')->nullable()->after('password');
+            $table->string('provider_id')->unique()->nullable()->after('provider');
         });
     }
 }

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -16,4 +16,35 @@ class UserTest extends TestCase
         $user = User::factory()->create();
         $this->assertNotNull($user);
     }
+
+    /** @test */
+    public function custom_fields()
+    {
+        $user = User::factory()->create([
+            'bio' => 'bio field',
+            'title' => 'title field',
+            'provider_name' => 'provider name field',
+            'provider_id' => 'provider id field',
+        ]);
+
+        /** @var User $result */
+        $result = User::findOrFail($user->id);
+
+        $this->assertEquals('bio field', $result->bio);
+        $this->assertEquals('title field', $result->title);
+        $this->assertEquals('provider name field', $result->provider_name);
+        $this->assertEquals('provider id field', $result->provider_id);
+    }
+
+    /** @test */
+    public function soft_delete()
+    {
+        $user = User::factory()->create();
+
+        $user->delete();
+
+        $user->refresh();
+
+        $this->assertNotNull($user->deleted_at);
+    }
 }


### PR DESCRIPTION
This migration is going to be the death of me!  Isolating the rename operation - along with the targeted default - appear to result in all columns actually being added!