### PR TITLE
split CreatePermissionsMigration in two; AddUserPermissionsMigration …

### DIFF
--- a/database/migrations/2021_03_01_100000_base_permissions_migration.php
+++ b/database/migrations/2021_03_01_100000_base_permissions_migration.php
@@ -6,22 +6,16 @@ use Illuminate\Database\Migrations\Migration;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Models\Role;
-use Illuminate\Support\Collection;
 
-class CreatePermissionsMigration extends Migration
+class BasePermissionsMigration extends Migration
 {
-    public function up()
+    public function createPermissions($permissions)
     {
         if (app()->has(Permission::class)) {
             $adminRole = Role::findByName('Admin');
 
             app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $permissions = [
-                'view users',
-                'create users',
-                'update users',
-            ];
-
+            
             foreach ($permissions as $permission) {
                 app(Permission::class)::findOrCreate($permission, null);
                 $adminRole->givePermissionTo($permission);

--- a/database/migrations/2021_03_01_110000_add_user_permissions_migration.php
+++ b/database/migrations/2021_03_01_110000_add_user_permissions_migration.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+class AddUserPermissionsMigration extends BasePermissionsMigration
+{
+    public function up()
+    {
+        $permissions = [
+            'view users',
+            'create users',
+            'update users',
+        ];
+
+        $this->createPermissions($permissions);
+    }
+}

--- a/database/migrations/2021_03_01_110000_add_user_permissions_migration.php
+++ b/database/migrations/2021_03_01_110000_add_user_permissions_migration.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Tipoff\Authorization\Permissions\BasePermissionsMigration;
+
 class AddUserPermissionsMigration extends BasePermissionsMigration
 {
     public function up()

--- a/src/Permissions/BasePermissionsMigration.php
+++ b/src/Permissions/BasePermissionsMigration.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Tipoff\Authorization\Permissions;
+
 use Illuminate\Database\Migrations\Migration;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\PermissionRegistrar;

--- a/src/Permissions/BasePermissionsMigration.php
+++ b/src/Permissions/BasePermissionsMigration.php
@@ -17,8 +17,9 @@ class BasePermissionsMigration extends Migration
             $adminRole = Role::findByName('Admin');
 
             app(PermissionRegistrar::class)->forgetCachedPermissions();
-            
+
             foreach ($permissions as $permission) {
+                /** @psalm-suppress UndefinedMethod */
                 app(Permission::class)::findOrCreate($permission, null);
                 $adminRole->givePermissionTo($permission);
             }

--- a/src/Permissions/BasePermissionsMigration.php
+++ b/src/Permissions/BasePermissionsMigration.php
@@ -6,8 +6,8 @@ namespace Tipoff\Authorization\Permissions;
 
 use Illuminate\Database\Migrations\Migration;
 use Spatie\Permission\Contracts\Permission;
-use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 
 class BasePermissionsMigration extends Migration
 {


### PR DESCRIPTION
closes #23 

- split CreatePermissionsMigration in two
- AddUserPermissionsMigration extends BasePermissionsMigration

After the previous branch was merged (omnia/feature/#78) some changes were reverted later

> There should be a PermissionMigration that is extended in all the other packages that has a short format for adding a list of new Permissions (#22) for that package.

The base class _PermissionMigration_ is now called _BasePermissionsMigration_
I added an actual implementation that extends it called _AddUserPermissionsMigration_

This is more in line with issue #23
I aligned this with the test fixes, so hopefully the tests do not break.
https://github.com/tipoff/authorization/commit/38f2930abf229ebd357dfaa8868e5d596c825589

