### PR TITLE
Fix after reference in migration

### DIFF
--- a/database/migrations/2014_10_12_000001_modify_users_table.php
+++ b/database/migrations/2014_10_12_000001_modify_users_table.php
@@ -28,7 +28,7 @@ class ModifyUsersTable extends Migration
 
             // needed for Laravel Socialite
             $table->string('provider_name')->nullable()->after('password');
-            $table->string('provider_id')->unique()->nullable()->after('provider');
+            $table->string('provider_id')->unique()->nullable()->after('provider_name');
         });
     }
 }


### PR DESCRIPTION
Seems sqlite may ignore the `after(..)` entirely.  This failed (as it should) when trying to run migrations in an app using mysql. 