### PR TITLE
Replace viewNova gate with our own, making sure we are last

### DIFF
--- a/src/AuthorizationServiceProvider.php
+++ b/src/AuthorizationServiceProvider.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Tipoff\Authorization;
 
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
-use Laravel\Nova\Events\NovaServiceProviderRegistered;
 use Laravel\Nova\Nova;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Authorization\Policies\UserPolicy;
@@ -41,6 +39,7 @@ class AuthorizationServiceProvider extends TipoffServiceProvider
                         return app()->environment('testing') ||
                             $user->hasPermissionTo('access admin');
                     }
+
                     return false;
                 });
             });

--- a/tests/Feature/Nova/UserResourceTest.php
+++ b/tests/Feature/Nova/UserResourceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Authorization\Tests\Feature\Nova;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Authorization\Models\User;
+use Tipoff\Authorization\Tests\TestCase;
+
+class UserResourceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function index()
+    {
+        User::factory()->count(4)->create();
+
+        $this->actingAs(self::createPermissionedUser('view users', true));
+
+        $response = $this->getJson('nova-api/users')
+            ->assertOk();
+
+        $this->assertCount(4, $response->json('resources'));
+    }
+
+    /** @test */
+    public function show()
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs(self::createPermissionedUser('view users', true));
+
+        $response = $this->getJson("nova-api/users/{$user->id}")
+            ->assertOk();
+
+        $this->assertEquals($user->id, $response->json('resource.id.value'));
+    }
+}


### PR DESCRIPTION
I don't like this solution, its too dependent on how other things are actually implemented, but it works.  It relies on the following:
* gate definitions are unique.  If a gate is defined a second time, the second definition replaces the first
* nova defers all of its registration until the ServingNova event is dispatched.  
* If we are the last listener for that event, we can replace the gate definition
* to be last, we defer registering for the ServingNova event until the NovaServiceProviderRegistered event is raised

I'll leave it up to you whether or not to use it. 