### PR TITLE
Enforce access admin permission even when testing

### DIFF
--- a/database/migrations/2021_02_01_110000_add_auth_permissions.php
+++ b/database/migrations/2021_02_01_110000_add_auth_permissions.php
@@ -9,7 +9,7 @@ class AddAuthPermissions extends BasePermissionsMigration
     public function up()
     {
         $permissions = [
-            'access admin' => ['Owner','Executive','Staff','Customer'],
+            'access admin' => ['Owner','Executive','Staff'],
             'view users' => ['Owner','Executive','Staff'],
             'create users' => ['Owner','Executive','Staff'],
             'update users' => ['Owner','Executive'],

--- a/src/AuthorizationServiceProvider.php
+++ b/src/AuthorizationServiceProvider.php
@@ -42,8 +42,7 @@ class AuthorizationServiceProvider extends TipoffServiceProvider
             Nova::serving(function () {
                 Gate::define('viewNova', function ($user) {
                     if ($user instanceof UserInterface) {
-                        return app()->environment('testing') ||
-                            $user->hasPermissionTo('access admin');
+                        return $user->hasPermissionTo('access admin');
                     }
 
                     return false;

--- a/tests/Feature/Nova/UserResourceTest.php
+++ b/tests/Feature/Nova/UserResourceTest.php
@@ -17,12 +17,12 @@ class UserResourceTest extends TestCase
     {
         User::factory()->count(4)->create();
 
-        $this->actingAs(self::createPermissionedUser('view users', true));
+        $this->actingAs(User::factory()->create()->assignRole('Admin'));
 
         $response = $this->getJson('nova-api/users')
             ->assertOk();
 
-        $this->assertCount(4, $response->json('resources'));
+        $this->assertCount(5, $response->json('resources'));
     }
 
     /** @test */
@@ -30,7 +30,7 @@ class UserResourceTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->actingAs(self::createPermissionedUser('view users', true));
+        $this->actingAs(User::factory()->create()->assignRole('Admin'));
 
         $response = $this->getJson("nova-api/users/{$user->id}")
             ->assertOk();


### PR DESCRIPTION
Not enforcing `access admin` permission during testing was making it difficult to properly test policies vs expected resutls.