### PR TITLE
Make EmailAddress Authenticatable - Checkout #85

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "vyuldashev/nova-permission": "^2.11"
     },
     "require-dev": {
-        "tipoff/test-support": "^1.4"
+        "tipoff/test-support": "dev-pdbreen/feature/checkout-85 as 1.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/socialite": "^5.2.2",
         "spatie/laravel-permission": "^4.0.1",
         "tipoff/support": "^1.8.7",
-        "vyuldashev/nova-permission": ""
+        "vyuldashev/nova-permission": "^2.11"
     },
     "require-dev": {
         "tipoff/test-support": "^1.4.1"

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "laravel/socialite": "^5.2.2",
         "spatie/laravel-permission": "^4.0.1",
         "tipoff/support": "^1.8.7",
-        "vyuldashev/nova-permission": "^2.11"
+        "vyuldashev/nova-permission": ""
     },
     "require-dev": {
-        "tipoff/test-support": "dev-pdbreen/feature/checkout-85 as 1.4.0"
+        "tipoff/test-support": "^1.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Models/EmailAddress.php
+++ b/src/Models/EmailAddress.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tipoff\Authorization\Models;
 
 use Carbon\Carbon;
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasPackageFactory;
 
@@ -19,9 +21,10 @@ use Tipoff\Support\Traits\HasPackageFactory;
  * @property Carbon created_at
  * @property Carbon updated_at
  */
-class EmailAddress extends BaseModel
+class EmailAddress extends BaseModel implements AuthenticatableContract
 {
     use HasPackageFactory;
+    use Authenticatable;
 
     protected $casts = [
         'verified_at' => 'datetime',
@@ -31,5 +34,10 @@ class EmailAddress extends BaseModel
     public function user()
     {
         return $this->belongsTo(app('user'));
+    }
+
+    public function getAuthPassword()
+    {
+        return '';
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -85,7 +85,14 @@ class User extends BaseModel implements UserInterface, CanResetPasswordContract,
         return $this->hasMany(app('email_address'));
     }
 
-    // @todo create email function to return string of the primary email address for the user
+    public function getPrimaryEmailAddress(): ?EmailAddress
+    {
+        // TODO - sorting by primary will ensure a primary address is returned when flagged, but also handle a missing flag
+        return $this->emailAddresses()
+            ->orderBy('primary', 'desc')
+            ->orderBy('created_at', 'asc')
+            ->first();
+    }
 
     public function locations()
     {
@@ -156,16 +163,14 @@ class User extends BaseModel implements UserInterface, CanResetPasswordContract,
 
     public function getEmailAttribute()
     {
-        /** @var EmailAddress $emailAddress */
-        $emailAddress = $this->emailAddresses()->where('primary', 1)->first();
+        $emailAddress = $this->getPrimaryEmailAddress();
 
         return $emailAddress ? $emailAddress->email : null;
     }
 
     public function getEmailVerifiedAtAttribute()
     {
-        /** @var EmailAddress $emailAddress */
-        $emailAddress = $this->emailAddresses()->where('primary', 1)->first();
+        $emailAddress = $this->getPrimaryEmailAddress();
 
         return $emailAddress ? $emailAddress->verified_at : null;
     }

--- a/tests/Unit/Models/EmailAddressTest.php
+++ b/tests/Unit/Models/EmailAddressTest.php
@@ -16,4 +16,18 @@ class EmailAddressTest extends TestCase
         $email = EmailAddress::factory()->create();
         $this->assertNotNull($email);
     }
+
+    /** @test */
+    public function act_as()
+    {
+        $email = EmailAddress::factory()->create();
+
+        $this->assertFalse($this->isAuthenticated('web'));
+        $this->assertFalse($this->isAuthenticated('email'));
+
+        $this->actingAs($email, 'email');
+
+        $this->assertFalse($this->isAuthenticated('web'));
+        $this->assertTrue($this->isAuthenticated('email'));
+    }
 }


### PR DESCRIPTION
* [x] requires updated --dev tipoff/test-support with guard/provider config updates before merge

---

Documentation / Installation note - this change requires the following additions to `config/auth.php`

```
    'guards' => [
        // ...
        'email' => [
            'driver' => 'session',
            'provider' => 'email',
        ],
        // ...
   ],
   // ...
    'providers' => [
        // ...
        'email' => [
            'driver' => 'eloquent',
            'model' => Tipoff\Authorization\Models\EmailAddress::class,
        ],
        // ...
   ],
   // ...
```