### PR TITLE
Add ability to search email address by email

### DIFF
--- a/src/Nova/EmailAddress.php
+++ b/src/Nova/EmailAddress.php
@@ -20,9 +20,9 @@ class EmailAddress extends BaseResource
     public static $title = 'email';
 
     public static $search = [
-        'id',
+        'id', 'email'
     ];
-    
+
     public static $group = 'Resources';
 
     public function fieldsForIndex(NovaRequest $request)

--- a/src/Nova/EmailAddress.php
+++ b/src/Nova/EmailAddress.php
@@ -20,7 +20,7 @@ class EmailAddress extends BaseResource
     public static $title = 'email';
 
     public static $search = [
-        'id', 'email'
+        'id', 'email',
     ];
 
     public static $group = 'Resources';


### PR DESCRIPTION
Currently, we cannot search email addresses by email, only id.

<img width="1594" alt="Screen Shot 2021-05-19 at 4 33 05 PM" src="https://user-images.githubusercontent.com/6707194/118897837-f6929d00-b8bf-11eb-8ac9-542b8ce77b59.png">
<img width="1538" alt="Screen Shot 2021-05-19 at 4 32 58 PM" src="https://user-images.githubusercontent.com/6707194/118897839-f7c3ca00-b8bf-11eb-94e0-1d02f2a13b54.png">
